### PR TITLE
bookmark favicons no longer floating on the right

### DIFF
--- a/styles/bookmark.css
+++ b/styles/bookmark.css
@@ -14,7 +14,7 @@ body {
 #wrap  a {
     text-decoration: none;
     display: block;
-    padding: 3px 15px;
+    padding: 3px 1px;
     clear: both;
     font-weight: normal;
     line-height: 20px;
@@ -63,10 +63,7 @@ a:hover {
 }
 
 .link .favicon {
-    position: absolute;
-    right: 4px;
     vertical-align: middle;
-    margin-right: 3px;
 }
 
 .link:hover .favicon {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/1161183/6426932/f4924cca-bf3e-11e4-9390-e4eafa66299a.png)
After:
![after](https://cloud.githubusercontent.com/assets/1161183/6426933/f6f54b66-bf3e-11e4-92dd-cd0d1586f159.png)
